### PR TITLE
Generating random string small fix

### DIFF
--- a/MissingFeatures.Tests/RandomGenerator/NextStringTests.cs
+++ b/MissingFeatures.Tests/RandomGenerator/NextStringTests.cs
@@ -1,5 +1,7 @@
 ﻿namespace MissingFeatures.Tests.RandomGenerator
 {
+    using System.Text;
+
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     using RandomGenerator = MissingFeatures.RandomGenerator;
@@ -8,12 +10,21 @@
     public class NextStringTests
     {
         [TestMethod]
-        public void NextStringShouldReturnStringWithSameNumberOfCharactersAsMethodParameter()
+        public void NextStringShouldReturnStringWithLessThanOrTheSameNumberOfCharactersAsMethodParameterWhenNoEncodingIsSpecified()
         {
-            const int NumberOfCharacters = 7;
+            const int MaxNumberOfCharacters = 7;
             var randomGenerator = new RandomGenerator();
-            var result = randomGenerator.NextString(NumberOfCharacters);
-            Assert.AreEqual(NumberOfCharacters, result.Length);
+            var result = randomGenerator.NextString(MaxNumberOfCharacters);
+            Assert.IsTrue(result.Length <= MaxNumberOfCharacters);
+        }
+
+        [TestMethod]
+        public void NextStringShouldReturnStringWithTheSameNumberOfCharactersAsMethodParameterWhenAsciiEncodingIsUsed()
+        {
+            const int MaxNumberOfCharacters = 7;
+            var randomGenerator = new RandomGenerator();
+            var result = randomGenerator.NextString(MaxNumberOfCharacters, Encoding.ASCII);
+            Assert.AreEqual(MaxNumberOfCharacters, result.Length);
         }
     }
 }

--- a/MissingFeatures.Tests/RandomGenerator/NextStringTests.cs
+++ b/MissingFeatures.Tests/RandomGenerator/NextStringTests.cs
@@ -21,10 +21,10 @@
         [TestMethod]
         public void NextStringShouldReturnStringWithTheSameNumberOfCharactersAsMethodParameterWhenAsciiEncodingIsUsed()
         {
-            const int MaxNumberOfCharacters = 7;
+            const int NumberOfCharacters = 7;
             var randomGenerator = new RandomGenerator();
-            var result = randomGenerator.NextString(MaxNumberOfCharacters, Encoding.ASCII);
-            Assert.AreEqual(MaxNumberOfCharacters, result.Length);
+            var result = randomGenerator.NextString(NumberOfCharacters, Encoding.ASCII);
+            Assert.AreEqual(NumberOfCharacters, result.Length);
         }
     }
 }

--- a/MissingFeatures/Contracts/IRandomGenerator.cs
+++ b/MissingFeatures/Contracts/IRandomGenerator.cs
@@ -18,6 +18,6 @@
 
         string NextHexString(int length);
 
-        string NextString(int length, Encoding encoding = null);
+        string NextString(int maxLength, Encoding encoding = null);
     }
 }

--- a/MissingFeatures/RandomGenerator.cs
+++ b/MissingFeatures/RandomGenerator.cs
@@ -86,14 +86,25 @@
             return value;
         }
 
-        public string NextString(int length, Encoding encoding = null)
+        /// <summary>
+        /// Retrieves a string of random characters with maximum length <paramref name="maxLength"/>
+        /// and in character encoding <paramref name="encoding"/>. If no encoding is specified
+        /// UTF8 is used.
+        /// </summary>
+        /// <param name="maxLength">The maximum length of the result string.</param>
+        /// <param name="encoding">The character encoding of the result string's characters.</param>
+        /// <returns>
+        /// A string of random characters with specified maximum length <paramref name="maxLength"/>
+        /// and in the specified character encoding <paramref name="encoding"/>.
+        /// </returns>
+        public string NextString(int maxLength, Encoding encoding = null)
         {
-            if (length < 0)
+            if (maxLength < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(length), "String length cannot be negative.");
+                throw new ArgumentOutOfRangeException(nameof(maxLength), "String length cannot be negative.");
             }
 
-            var bytes = this.GetRandomBytes(length);
+            var bytes = this.GetRandomBytes(maxLength);
 
             if (encoding == null)
             {


### PR DESCRIPTION
Fixed generating random string to take into consideration that some encodings use more than one byte to represent a character.